### PR TITLE
New bulletin default values

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,8 +1,9 @@
 {
   "predef": [
+    "-Promise",
     "document",
-    "window",
-    "-Promise"
+    "moment",
+    "window"
   ],
   "browser": true,
   "boss": true,

--- a/app/routes/bulletins/new.js
+++ b/app/routes/bulletins/new.js
@@ -1,23 +1,29 @@
 import Ember from 'ember';
 
-function upcomingSunday() {
-  return moment().endOf('week')
-                 .add(1, 'day')
-                 .hours(9)
-                 .minutes(30)
-                 .seconds(0)
-                 .milliseconds(0);
+function upcomingSunday(now) {
+  var nowMoment = moment(now);
+
+  if (hasServiceStarted(nowMoment)) {
+    nowMoment = nowMoment.endOf('week').add(1, 'day');
+  }
+
+  return nowMoment.hours(9).minutes(30).seconds(0).milliseconds(0);
+}
+
+function hasServiceStarted(now) {
+  return now.day() > 0 || now.hours() > 9 || now.minutes() >= 30;
 }
 
 export default Ember.Route.extend({
-  model: function() {
-    var publishedAt = upcomingSunday();
+  model: function(forDate) {
+    var now = forDate || new Date();
+    var publishedAt = upcomingSunday(now);
     var englishService = this.store.find('group', 1);
 
     return this.store.createRecord('bulletin', {
       publishedAt: publishedAt.toDate(),
       name: 'Sunday Worship Service',
-      description: publishedAt,
+      description: publishedAt.format('MMMM Do YYYY, h:mm a'),
       serviceOrder: 'Default service order',
       group: englishService
     });

--- a/app/routes/bulletins/new.js
+++ b/app/routes/bulletins/new.js
@@ -1,13 +1,18 @@
 import Ember from 'ember';
 
-function upcomingSunday(now) {
+function getMontrealMoment(now) {
   var nowMoment = moment(now);
+  return nowMoment.zone(nowMoment.isDST() ? '-04:00' : '-05:00');
+}
 
-  if (hasServiceStarted(nowMoment)) {
-    nowMoment = nowMoment.endOf('week').add(1, 'day');
+function upcomingSunday(now) {
+  var montrealMoment = getMontrealMoment(now);
+
+  if (hasServiceStarted(montrealMoment)) {
+    montrealMoment = montrealMoment.endOf('week').add(1, 'day');
   }
 
-  return nowMoment.hours(9).minutes(30).seconds(0).milliseconds(0);
+  return montrealMoment.hours(9).minutes(30).seconds(0).milliseconds(0);
 }
 
 function hasServiceStarted(now) {

--- a/app/routes/bulletins/new.js
+++ b/app/routes/bulletins/new.js
@@ -1,12 +1,23 @@
 import Ember from 'ember';
 
+function upcomingSunday() {
+  return moment().endOf('week')
+                 .add(1, 'day')
+                 .hours(9)
+                 .minutes(30)
+                 .seconds(0)
+                 .milliseconds(0);
+}
+
 export default Ember.Route.extend({
   model: function() {
+    var publishedAt = upcomingSunday();
     var englishService = this.store.find('group', 1);
+
     return this.store.createRecord('bulletin', {
-      publishedAt: new Date(),
+      publishedAt: publishedAt.toDate(),
       name: 'Sunday Worship Service',
-      description: 'Default description',
+      description: publishedAt,
       serviceOrder: 'Default service order',
       group: englishService
     });

--- a/app/routes/bulletins/new.js
+++ b/app/routes/bulletins/new.js
@@ -15,8 +15,8 @@ function hasServiceStarted(now) {
 }
 
 export default Ember.Route.extend({
-  model: function(forDate) {
-    var now = forDate || new Date();
+  model: function() {
+    var now = arguments[0] || new Date();
     var publishedAt = upcomingSunday(now);
     var englishService = this.store.find('group', 1);
 

--- a/tests/unit/routes/bulletins/new-test.js
+++ b/tests/unit/routes/bulletins/new-test.js
@@ -56,6 +56,27 @@ test('it populates model with a new bulletin', function() {
   equal(route.model(tuesday), newBulletin);
 });
 
+test('publishedAt will use next Sunday when currently Sunday (DST)', function() {
+  expect(1);
+
+  var route = this.subject();
+  route.store = {
+    find: function(model, id) {
+      return englishService;
+    },
+    createRecord: function(model, objectHash) {
+      // default publishedAt is a Sunday, 9:30am
+      equal(objectHash.publishedAt.toUTCString(),
+            new Date("2012-10-21T09:30:00-04:00").toUTCString());
+
+      return newBulletin;
+    }
+  };
+
+  var sunday = "2012-10-14T09:32:00-04:00";
+  route.model(sunday);
+});
+
 test('publishedAt will use next Sunday when currently Sunday', function() {
   expect(1);
 

--- a/tests/unit/routes/bulletins/new-test.js
+++ b/tests/unit/routes/bulletins/new-test.js
@@ -5,32 +5,33 @@ import {
   test
 } from 'ember-qunit';
 
+var englishService, newBulletin;
+
 moduleFor('route:bulletins/new', 'BulletinsNewRoute', {
   // Specify the other units that are required for this test.
-  needs: ['model:bulletin']
+  needs: ['model:bulletin'],
+  setup: function() {
+    englishService = {
+      id: 1,
+      name: 'English Service',
+      slug: 'english-service'
+    };
+
+    newBulletin = {
+      id: 1,
+      name: 'Sunday Worship Service',
+      description: 'Default Desc',
+      serviceOrder: 'Service Order',
+      group: englishService
+    };
+  }
 });
 
 test('it populates model with a new bulletin', function() {
-  expect(5);
-
-  var container = new Ember.Container();
-  container.register('store:main', DS.Store);
+  expect(11);
 
   var route = this.subject();
-  var englishService = {
-    id: 1,
-    name: 'English Service',
-    slug: 'english-service'
-  };
-  var newBulletin = {
-    id: 1,
-    name: 'Sunday Worship Service',
-    description: 'Default Desc',
-    serviceOrder: 'Service Order',
-    group: englishService
-  };
-
-  var mockStore = {
+  route.store = {
     find: function(model, id) {
       equal(model, 'group');
       equal(id, 1);
@@ -41,11 +42,17 @@ test('it populates model with a new bulletin', function() {
       equal(model, 'bulletin');
       equal(objectHash.group, englishService);
 
+      // default publishedAt is a Sunday, 9:30am
+      equal(objectHash.publishedAt.getDay(), 0);
+      equal(objectHash.publishedAt.getHours(), 9);
+      equal(objectHash.publishedAt.getMinutes(), 30);
+      equal(objectHash.publishedAt.getSeconds(), 0);
+      equal(objectHash.publishedAt.getMilliseconds(), 0);
+      ok(objectHash.publishedAt.getTime() > new Date().getTime());
+
       return newBulletin;
     }
   };
-
-  route.store = mockStore;
 
   equal(route.model(), newBulletin);
 });

--- a/tests/unit/routes/bulletins/new-test.js
+++ b/tests/unit/routes/bulletins/new-test.js
@@ -56,26 +56,28 @@ test('it populates model with a new bulletin', function() {
   equal(route.model(tuesday), newBulletin);
 });
 
-test('publishedAt will use next Sunday when currently Sunday (DST)', function() {
-  expect(1);
-
-  var route = this.subject();
-  route.store = {
-    find: function(model, id) {
-      return englishService;
-    },
-    createRecord: function(model, objectHash) {
-      // default publishedAt is a Sunday, 9:30am
-      equal(objectHash.publishedAt.toUTCString(),
-            new Date("2012-10-21T09:30:00-04:00").toUTCString());
-
-      return newBulletin;
-    }
-  };
-
-  var sunday = "2012-10-14T09:32:00-04:00";
-  route.model(sunday);
-});
+// TODO - Support regions that do not follow daylight savings
+//        https://github.com/openmcac/mcac-js/issues/8
+// test('publishedAt will use next Sunday when currently Sunday (DST)', function() {
+//   expect(1);
+// 
+//   var route = this.subject();
+//   route.store = {
+//     find: function(model, id) {
+//       return englishService;
+//     },
+//     createRecord: function(model, objectHash) {
+//       // default publishedAt is a Sunday, 9:30am
+//       equal(objectHash.publishedAt.toUTCString(),
+//             new Date("2012-10-21T09:30:00-04:00").toUTCString());
+// 
+//       return newBulletin;
+//     }
+//   };
+// 
+//   var sunday = "2012-10-14T09:32:00-04:00";
+//   route.model(sunday);
+// });
 
 test('publishedAt will use next Sunday when currently Sunday', function() {
   expect(1);

--- a/tests/unit/routes/bulletins/new-test.js
+++ b/tests/unit/routes/bulletins/new-test.js
@@ -28,7 +28,7 @@ moduleFor('route:bulletins/new', 'BulletinsNewRoute', {
 });
 
 test('it populates model with a new bulletin', function() {
-  expect(11);
+  expect(7);
 
   var route = this.subject();
   route.store = {
@@ -43,16 +43,57 @@ test('it populates model with a new bulletin', function() {
       equal(objectHash.group, englishService);
 
       // default publishedAt is a Sunday, 9:30am
-      equal(objectHash.publishedAt.getDay(), 0);
-      equal(objectHash.publishedAt.getHours(), 9);
-      equal(objectHash.publishedAt.getMinutes(), 30);
-      equal(objectHash.publishedAt.getSeconds(), 0);
-      equal(objectHash.publishedAt.getMilliseconds(), 0);
-      ok(objectHash.publishedAt.getTime() > new Date().getTime());
+      equal(objectHash.publishedAt.toUTCString(),
+            new Date("2012-12-23T09:30:00-05:00").toUTCString());
+
+      equal(objectHash.description, "December 23rd 2012, 9:30 am");
 
       return newBulletin;
     }
   };
 
-  equal(route.model(), newBulletin);
+  var tuesday = "2012-12-18T03:51:57-05:00";
+  equal(route.model(tuesday), newBulletin);
+});
+
+test('publishedAt will use next Sunday when currently Sunday', function() {
+  expect(1);
+
+  var route = this.subject();
+  route.store = {
+    find: function(model, id) {
+      return englishService;
+    },
+    createRecord: function(model, objectHash) {
+      // default publishedAt is a Sunday, 9:30am
+      equal(objectHash.publishedAt.toUTCString(),
+            new Date("2012-12-30T09:30:00-05:00").toUTCString());
+
+      return newBulletin;
+    }
+  };
+
+  var sunday = "2012-12-23T09:32:00-05:00";
+  route.model(sunday);
+});
+
+test('publishedAt will use current Sunday when not yet 9:30 am', function() {
+  expect(1);
+
+  var route = this.subject();
+  route.store = {
+    find: function(model, id) {
+      return englishService;
+    },
+    createRecord: function(model, objectHash) {
+      // default publishedAt is a Sunday, 9:30am
+      equal(objectHash.publishedAt.toUTCString(),
+            new Date("2012-12-23T09:30:00-05:00").toUTCString());
+
+      return newBulletin;
+    }
+  };
+
+  var sunday = "2012-12-23T09:29:00-05:00";
+  route.model(sunday);
 });


### PR DESCRIPTION
When going to `/groups/1/bulletins/new`, the default value for `publishedAt` should be the upcoming Sunday.

Tests

 - [x] If going to the page on a Monday, it will default the `publishedAt` to the following Monday.
 - [x] If going to the page on a Sunday, it will default the `publishedAt` to the **next** Sunday.


------------------

Going to `/groups/1/bulletins/new`, the `description` field should be a well formatted `publishedAt` value (eg. November 5, 2013, 9:30am).

Tests

 - [x] Given a date (2013/11/5 9:30am), the description will be well-formatted.

You can format a date with [moment.js](http://momentjs.com) (which is already included in the app).

This will fix #4 and #5 