### PR TITLE
Add a Markdown editor into the bulletin form

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -21,6 +21,7 @@ app.import('bower_components/bootstrap/dist/js/bootstrap.js');
 app.import('bower_components/bootstrap/dist/css/bootstrap.css');
 app.import('bower_components/moment-timezone/builds/moment-timezone-with-data-2010-2020.js');
 app.import('bower_components/bootstrap-markdown/js/bootstrap-markdown.js');
+app.import('bower_components/bootstrap-markdown/css/bootstrap-markdown.min.css');
 
 var mergeTrees = require('broccoli-merge-trees');
 var pickFiles = require('broccoli-static-compiler');

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -20,6 +20,7 @@ var app = new EmberApp();
 app.import('bower_components/bootstrap/dist/js/bootstrap.js');
 app.import('bower_components/bootstrap/dist/css/bootstrap.css');
 app.import('bower_components/moment-timezone/builds/moment-timezone-with-data-2010-2020.js');
+app.import('bower_components/bootstrap-markdown/js/bootstrap-markdown.js');
 
 var mergeTrees = require('broccoli-merge-trees');
 var pickFiles = require('broccoli-static-compiler');

--- a/app/app.js
+++ b/app/app.js
@@ -13,4 +13,13 @@ var App = Ember.Application.extend({
 
 loadInitializers(App, config.modulePrefix);
 
+Ember.TextArea.reopen({
+  attributeBindings: ['data-provide'],
+  didInsertElement: function() {
+    Ember.$('textarea').each(function() {
+      Ember.$(this).markdown();
+    });
+  }
+});
+
 export default App;

--- a/app/app.js
+++ b/app/app.js
@@ -13,13 +13,4 @@ var App = Ember.Application.extend({
 
 loadInitializers(App, config.modulePrefix);
 
-Ember.TextArea.reopen({
-  attributeBindings: ['data-provide'],
-  didInsertElement: function() {
-    Ember.$('textarea').each(function() {
-      Ember.$(this).markdown();
-    });
-  }
-});
-
 export default App;

--- a/app/components/markdown-textarea.js
+++ b/app/components/markdown-textarea.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.TextArea.extend({
+  attributeBindings: ['data-provide'],
+  classNames: ['markdown-textarea'],
+  renderEditor: function() {
+    this.$().markdown();
+  }.on('didInsertElement')
+});

--- a/app/templates/bulletins/new.hbs
+++ b/app/templates/bulletins/new.hbs
@@ -14,9 +14,14 @@
     </div>
     <div class="form-group">
       <label for="serviceOrder">Order</label>
-      {{textarea data-provide="markdown" id="serviceOrder" value=serviceOrder class="form-control" rows="10"}}
+      {{markdown-textarea id="serviceOrder"
+                          value=serviceOrder
+                          class="form-control"
+                          rows="10"}}
     </div>
-    <button type="submit" {{action 'save'}} class="btn btn-default">Save</button>
+    <button type="submit" {{action 'save'}} class="btn btn-default">
+      Save
+    </button>
   </form>
 </div>
 {{outlet}}

--- a/app/templates/bulletins/new.hbs
+++ b/app/templates/bulletins/new.hbs
@@ -14,7 +14,7 @@
     </div>
     <div class="form-group">
       <label for="serviceOrder">Order</label>
-      {{textarea id="serviceOrder" value=serviceOrder class="form-control" rows="10"}}
+      {{textarea data-provide="markdown" id="serviceOrder" value=serviceOrder class="form-control" rows="10"}}
     </div>
     <button type="submit" {{action 'save'}} class="btn btn-default">Save</button>
   </form>

--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
     "eonasdan-bootstrap-datetimepicker": "~3.1.3",
     "moment": "~2.8.4",
     "ember-cli-moment-shim": "~0.0.2",
-    "moment-timezone": "~0.2.5"
+    "moment-timezone": "~0.2.5",
+    "bootstrap-markdown": "~2.8.0"
   }
 }

--- a/tests/unit/components/markdown-textarea-test.js
+++ b/tests/unit/components/markdown-textarea-test.js
@@ -1,3 +1,5 @@
+import Ember from 'ember';
+
 import {
   moduleForComponent,
   test
@@ -13,9 +15,41 @@ test('it renders', function() {
 
   // creates the component instance
   var component = this.subject();
+
   equal(component._state, 'preRender');
 
   // appends the component to the page
   this.append();
+
   equal(component._state, 'inDOM');
+});
+
+test('it renders markdown editor on DOM element', function() {
+  expect(1);
+
+  var component = this.subject();
+
+  var renderEditorFn = component.renderEditor;
+  component.renderEditor = function() {
+    var $element = this.$();
+    $element.markdown = function() {
+      ok('markdown editor is rendered on dom element');
+    };
+
+    this.$ = function() {
+      return $element;
+    };
+
+    renderEditorFn.apply(this);
+  };
+
+  // appends the component to the page
+  this.append();
+});
+
+test('it sets the correct attributes', function() {
+  expect(2);
+  var component = this.subject();
+  ok(component.attributeBindings.indexOf('data-provide') > -1);
+  ok(component.classNames.indexOf('markdown-textarea') > -1);
 });

--- a/tests/unit/components/markdown-textarea-test.js
+++ b/tests/unit/components/markdown-textarea-test.js
@@ -1,0 +1,21 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('markdown-textarea', 'MarkdownTextareaComponent', {
+  // specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar']
+});
+
+test('it renders', function() {
+  expect(2);
+
+  // creates the component instance
+  var component = this.subject();
+  equal(component._state, 'preRender');
+
+  // appends the component to the page
+  this.append();
+  equal(component._state, 'inDOM');
+});


### PR DESCRIPTION
 - [x] Include `bootstrap-markdown` in the build 
 - [x] Creating a reusable `MarkdownTextarea` component
 - [x] Use `{{markdown-textarea}}` in the bulletin form for `serviceOrder`
 - [x] Test that bootstrap markdown is invoked once per component

Fulfils #6 and blocks #11.

Removed from scope:

 - Add markdown library to render markdown