### PR TITLE
Move group routes to /:group_slug

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -6,7 +6,7 @@ var Router = Ember.Router.extend({
 });
 
 Router.map(function() {
-  this.resource('group', { path: 'groups/:group_id' }, function() {
+  this.resource('group', { path: ':group_slug' }, function() {
     this.resource('bulletin', { path: 'bulletins/:bulletin_id' }, function() {
     });
 

--- a/app/routes/group.js
+++ b/app/routes/group.js
@@ -1,5 +1,10 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  
+  model: function(params) {
+    return this.store.find('group', { slug: params.group_slug })
+              .then(function(groups) {
+      return groups.get('firstObject');
+    });
+  }
 });

--- a/server/mocks/groups.js
+++ b/server/mocks/groups.js
@@ -2,9 +2,23 @@ module.exports = function(app) {
   var express = require('express');
   var groupsRouter = express.Router();
 
+  var englishService = {
+    "group": {
+      "id": 1,
+      "name": "English Service",
+      "slug": "english-service"
+    }
+  };
+
   groupsRouter.get('/', function(req, res) {
+    var groups = [];
+
+    if (!!req.query || req.query.slug === 'english-service') {
+      groups.push(englishService.group);
+    }
+
     res.send({
-      "groups": []
+      "groups": groups
     });
   });
 
@@ -13,13 +27,7 @@ module.exports = function(app) {
   });
 
   groupsRouter.get('/:id', function(req, res) {
-    res.send({
-      "group": {
-        "id": req.params.id,
-        "name": "English Service",
-        "slug": "english-service"
-      }
-    });
+    res.send(englishService);
   });
 
   groupsRouter.put('/:id', function(req, res) {

--- a/tests/unit/routes/group-test.js
+++ b/tests/unit/routes/group-test.js
@@ -1,3 +1,5 @@
+import Ember from 'ember';
+
 import {
   moduleFor,
   test
@@ -5,10 +7,30 @@ import {
 
 moduleFor('route:group', 'GroupRoute', {
   // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  // needs: ['model:group']
 });
 
-test('it exists', function() {
+test('model hook returns the group matching the slug provided', function() {
+  expect(3);
+
   var route = this.subject();
-  ok(route);
+  var expectedGroup = { dummy: true };
+  var groupSlug = "my-slug";
+
+  route.store = {
+    find: function(model, hash) {
+      equal('group', model);
+      equal(groupSlug, hash.slug);
+
+      return DS.PromiseArray.create({
+        promise: new Ember.RSVP.Promise(function(resolve, reject) {
+          resolve([expectedGroup]);
+        })
+      });
+    }
+  };
+
+  route.model({ group_slug: groupSlug }).then(function(group) {
+    equal(expectedGroup, group);
+  });
 });


### PR DESCRIPTION
 - [x] Update our mock server for groups (https://github.com/openmcac/mcac-js/blob/master/server/mocks/groups.js) to only respond to group slugs instead of ids
 - [x] Update the router to view groups via `/:group_slug`
 - [x] Update `GroupRoute` to fetch group model via `/groups?slug=#{slug}`
 - [x] Add tests for `GroupRoute`

Closes #12 