### PR TITLE
Populate bulletin with the most recent bulletin's announcements

### DIFF
--- a/app/models/announcement.js
+++ b/app/models/announcement.js
@@ -1,0 +1,10 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  description: DS.attr('string'),
+  position: DS.attr('number'),
+  bulletin: DS.belongsTo('bulletin'),
+  descriptionHtml: function() {
+    return marked(this.get('description'));
+  }.property('description')
+});

--- a/app/models/bulletin.js
+++ b/app/models/bulletin.js
@@ -6,6 +6,7 @@ export default DS.Model.extend({
   serviceOrder: DS.attr('string'),
   description: DS.attr('string'),
   group: DS.belongsTo('group'),
+  announcements: DS.hasMany('announcement'),
   serviceOrderHtml: function() {
     return marked(this.get('serviceOrder'));
   }.property('serviceOrder')

--- a/app/routes/bulletin/sunday.js
+++ b/app/routes/bulletin/sunday.js
@@ -8,6 +8,9 @@ export default Ember.Route.extend({
       var group = _this.store.normalize('group', data.group);
       _this.store.push('group', group);
 
+      var announcements = _this.store.normalize('announcement', data.announcements);
+      _this.store.pushMany('announcement', announcements);
+
       var bulletin = _this.store.normalize('bulletin', data.bulletin);
       return _this.store.push('bulletin', bulletin);
     });

--- a/app/routes/bulletins/new.js
+++ b/app/routes/bulletins/new.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import request from 'ic-ajax';
 
 function upcomingSunday(now) {
   var montrealMoment = moment(now).tz('America/Montreal');
@@ -16,25 +17,33 @@ function hasServiceStarted(now) {
 
 export default Ember.Route.extend({
   model: function() {
+    var _this = this;
     var now = (arguments[0] && arguments[0].currentTime) || new Date();
     var publishedAt = upcomingSunday(now);
     var group = this.modelFor('group');
+    var latestAnnouncementsEndpoint =
+        '/api/v1/announcements/latest?group_id=' + group.id;
 
-    var defaultBulletin = this.store.createRecord('bulletin', {
-      publishedAt: publishedAt.toDate(),
-      name: 'Sunday Worship Service',
-      description: publishedAt.format('MMMM Do YYYY, h:mm a'),
-      serviceOrder: 'Default service order',
-      group: group
+    return request(latestAnnouncementsEndpoint).then(function(data) {
+      var hash = _this.store.normalize('announcement', data.announcements);
+      _this.store.pushMany('announcement', hash);
+
+      var defaultBulletin = _this.store.createRecord('bulletin', {
+        publishedAt: publishedAt.toDate(),
+        name: 'Sunday Worship Service',
+        description: publishedAt.format('MMMM Do YYYY, h:mm a'),
+        serviceOrder: 'Default service order',
+        group: group
+      });
+
+      hash.forEach(function(currentAnnouncement) {
+        delete currentAnnouncement.id;
+        currentAnnouncement.bulletin = defaultBulletin;
+        var announcement = _this.store.createRecord('announcement', currentAnnouncement);
+        defaultBulletin.get('announcements').addObject(announcement);
+      });
+
+      return defaultBulletin;
     });
-
-    // defaultBulletin.get('announcements').then(function(announcements) {
-    //   announcements.pushObject(this.store.createRecord('announcement', {
-    //     description: 'welcome to mcac',
-    //     position: 1
-    //   }));
-    // });
-
-    return defaultBulletin;
   }
 });

--- a/app/routes/bulletins/new.js
+++ b/app/routes/bulletins/new.js
@@ -20,12 +20,21 @@ export default Ember.Route.extend({
     var publishedAt = upcomingSunday(now);
     var group = this.modelFor('group');
 
-    return this.store.createRecord('bulletin', {
+    var defaultBulletin = this.store.createRecord('bulletin', {
       publishedAt: publishedAt.toDate(),
       name: 'Sunday Worship Service',
       description: publishedAt.format('MMMM Do YYYY, h:mm a'),
       serviceOrder: 'Default service order',
       group: group
     });
+
+    // defaultBulletin.get('announcements').then(function(announcements) {
+    //   announcements.pushObject(this.store.createRecord('announcement', {
+    //     description: 'welcome to mcac',
+    //     position: 1
+    //   }));
+    // });
+
+    return defaultBulletin;
   }
 });

--- a/app/routes/bulletins/new.js
+++ b/app/routes/bulletins/new.js
@@ -5,8 +5,7 @@ import nextService from 'mcac/utils/next-service';
 export default Ember.Route.extend({
   model: function() {
     var _this = this;
-    var now = (arguments[0] && arguments[0].currentTime) || new Date();
-    var publishedAt = nextService(now);
+    var publishedAt = nextService();
     var group = this.modelFor('group');
     var latestAnnouncementsEndpoint =
         '/api/v1/announcements/latest?group_id=' + group.id;
@@ -24,9 +23,10 @@ export default Ember.Route.extend({
       });
 
       hash.forEach(function(currentAnnouncement) {
-        delete currentAnnouncement.id;
-        currentAnnouncement.bulletin = defaultBulletin;
-        var announcement = _this.store.createRecord('announcement', currentAnnouncement);
+        var announcement = Ember.copy(currentAnnouncement);
+        announcement.bulletin = defaultBulletin;
+        delete announcement.id;
+        announcement = _this.store.createRecord('announcement', announcement);
         defaultBulletin.get('announcements').addObject(announcement);
       });
 

--- a/app/routes/bulletins/new.js
+++ b/app/routes/bulletins/new.js
@@ -1,25 +1,12 @@
 import Ember from 'ember';
 import request from 'ic-ajax';
-
-function upcomingSunday(now) {
-  var montrealMoment = moment(now).tz('America/Montreal');
-
-  if (hasServiceStarted(montrealMoment)) {
-    montrealMoment = montrealMoment.endOf('week').add(1, 'day');
-  }
-
-  return montrealMoment.hours(9).minutes(30).seconds(0).milliseconds(0);
-}
-
-function hasServiceStarted(now) {
-  return now.day() > 0 || now.hours() > 9 || now.minutes() >= 30;
-}
+import nextService from 'mcac/utils/next-service';
 
 export default Ember.Route.extend({
   model: function() {
     var _this = this;
     var now = (arguments[0] && arguments[0].currentTime) || new Date();
-    var publishedAt = upcomingSunday(now);
+    var publishedAt = nextService(now);
     var group = this.modelFor('group');
     var latestAnnouncementsEndpoint =
         '/api/v1/announcements/latest?group_id=' + group.id;

--- a/app/routes/bulletins/new.js
+++ b/app/routes/bulletins/new.js
@@ -2,6 +2,22 @@ import Ember from 'ember';
 import request from 'ic-ajax';
 import nextService from 'mcac/utils/next-service';
 
+function addAnnouncementsToBulletin(store, announcmentsHash, bulletin) {
+  announcmentsHash.forEach(function(currentAnnouncement) {
+    var announcement = createAnnouncementForBulletin(store,
+                                                     currentAnnouncement,
+                                                     bulletin);
+    bulletin.get('announcements').addObject(announcement);
+  });
+}
+
+function createAnnouncementForBulletin(store, announcementHash, bulletin) {
+  var announcement = Ember.copy(announcementHash);
+  delete announcement.id;
+  announcement.bulletin = bulletin;
+  return store.createRecord('announcement', announcement);
+}
+
 export default Ember.Route.extend({
   model: function() {
     var _this = this;
@@ -22,13 +38,7 @@ export default Ember.Route.extend({
         group: group
       });
 
-      hash.forEach(function(currentAnnouncement) {
-        var announcement = Ember.copy(currentAnnouncement);
-        announcement.bulletin = defaultBulletin;
-        delete announcement.id;
-        announcement = _this.store.createRecord('announcement', announcement);
-        defaultBulletin.get('announcements').addObject(announcement);
-      });
+      addAnnouncementsToBulletin(_this.store, hash, defaultBulletin);
 
       return defaultBulletin;
     });

--- a/app/utils/next-service.js
+++ b/app/utils/next-service.js
@@ -1,0 +1,18 @@
+function upcomingSunday(now) {
+  var montrealMoment = moment(now).tz('America/Montreal');
+
+  if (hasServiceStarted(montrealMoment)) {
+    montrealMoment = montrealMoment.endOf('week').add(1, 'day');
+  }
+
+  return montrealMoment.hours(9).minutes(30).seconds(0).milliseconds(0);
+}
+
+function hasServiceStarted(now) {
+  return now.day() > 0 || now.hours() > 9 || now.minutes() >= 30;
+}
+
+export default function nextService() {
+  var now = arguments[0] || new Date();
+  return upcomingSunday(now);
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
     "broccoli-merge-trees": "^0.2.1",
     "broccoli-static-compiler": "^0.2.1",
+    "connect-restreamer": "^1.0.1",
     "ember-bootstrap-datetimepicker": "^0.2.7",
     "ember-cli": "0.1.5",
     "ember-cli-blanket": "^0.2.2",
@@ -39,6 +40,6 @@
     "ember-marked": "0.0.4",
     "express": "^4.8.5",
     "glob": "^4.0.5",
-    "morgan": "^1.5.0"
+    "morgan": "^1.5.1"
   }
 }

--- a/server/mocks/announcements.js
+++ b/server/mocks/announcements.js
@@ -12,6 +12,38 @@ module.exports = function(app) {
     res.status(201).end();
   });
 
+  announcementsRouter.get('/latest', function(req, res) {
+    if (typeof req.query.group_id === 'undefined') {
+      return res.status(500).end();
+    }
+
+    res.send({
+      "announcements": [
+        {
+          "id": 1,
+          "description": "This is the first announcement",
+          "bulletin": 1,
+          "post": 1,
+          "position": 1
+        },
+        {
+          "id": 2,
+          "description": "This is the second announcement",
+          "bulletin": 1,
+          "post": 2,
+          "position": 2
+        },
+        {
+          "id": 3,
+          "description": "This is the third announcement",
+          "bulletin": 1,
+          "post": 3,
+          "position": 3
+        }
+      ]
+    });
+  });
+
   announcementsRouter.get('/:id', function(req, res) {
     res.send({
       'announcements': {
@@ -32,5 +64,5 @@ module.exports = function(app) {
     res.status(204).end();
   });
 
-  app.use('/api/announcements', announcementsRouter);
+  app.use('/api/v1/announcements', announcementsRouter);
 };

--- a/server/mocks/announcements.js
+++ b/server/mocks/announcements.js
@@ -1,0 +1,36 @@
+module.exports = function(app) {
+  var express = require('express');
+  var announcementsRouter = express.Router();
+
+  announcementsRouter.get('/', function(req, res) {
+    res.send({
+      'announcements': []
+    });
+  });
+
+  announcementsRouter.post('/', function(req, res) {
+    res.status(201).end();
+  });
+
+  announcementsRouter.get('/:id', function(req, res) {
+    res.send({
+      'announcements': {
+        id: req.params.id
+      }
+    });
+  });
+
+  announcementsRouter.put('/:id', function(req, res) {
+    res.send({
+      'announcements': {
+        id: req.params.id
+      }
+    });
+  });
+
+  announcementsRouter.delete('/:id', function(req, res) {
+    res.status(204).end();
+  });
+
+  app.use('/api/announcements', announcementsRouter);
+};

--- a/server/mocks/sunday.js
+++ b/server/mocks/sunday.js
@@ -24,7 +24,16 @@ module.exports = function(app) {
         "id": 1,
         "slug": "english-service",
         "name": "English Service"
-      }
+      },
+      "announcements": [
+        {
+          "id": 1,
+          "description": "This is the first announcement",
+          "bulletin": 1,
+          "post": 1,
+          "position": 1
+        }
+      ]
     });
   });
 

--- a/tests/acceptance/routes/bulletin/sunday-test.js
+++ b/tests/acceptance/routes/bulletin/sunday-test.js
@@ -10,7 +10,7 @@ var application,
     TestHelper = Ember.Object.createWithMixins(FactoryGuyTestMixin);
 
 module('Acceptance: /sunday route', {
-  needs: ['model:bulletin'],
+  needs: ['model:bulletin', 'model:announcement'],
   setup: function() {
     defineFixture('/api/v1/sunday', {
       response: {
@@ -21,21 +21,36 @@ module('Acceptance: /sunday route', {
           "serviceOrder": "This is the service order.",
           "description": "This is a service bulletin.",
           "group": 1,
-          "announcements": [
-            {
-              "id": 1,
-              "description": "This is an announcement",
-              "bulletinId": 1,
-              "postId": 1,
-              "position": 1
-            }
-          ]
+          "announcements": [1, 2, 3]
         },
         "group": {
           "id": 1,
           "slug": "english-service",
           "name": "English Service"
-        }
+        },
+        "announcements": [
+          {
+            "id": 1,
+            "description": "This is the first announcement",
+            "bulletin": 1,
+            "post": 1,
+            "position": 1
+          },
+          {
+            "id": 2,
+            "description": "This is the second announcement",
+            "bulletin": 1,
+            "post": 2,
+            "position": 2
+          },
+          {
+            "id": 3,
+            "description": "This is the third announcement",
+            "bulletin": 1,
+            "post": 3,
+            "position": 3
+          }
+        ]
       }
     });
 
@@ -55,19 +70,43 @@ module('Acceptance: /sunday route', {
 });
 
 test('route returns model from /api/v1/sunday', function() {
-  expect(4);
+  expect(10);
   visit('/sunday');
 
   andThen(function() {
     var controller = application.__container__
                                 .lookup('controller:bulletin/sunday/index');
+
+    // it populates the bulletin attributes
     var model = controller.model;
     equal(model.get('name'), 'Sunday Service');
     equal(model.get('publishedAt').getTime(),
           new Date('2014-12-21T13:58:27-05:00').getTime());
 
+    // it populates the bulletin's group
     var group = model.get('group');
     equal(group.get('name'), 'English Service');
     equal(group.get('slug'), 'english-service');
+
+    // it populates the bulletin's announcements
+    var announcements = model.get('announcements');
+    announcementEqual(announcements.objectAt(0), {
+      description: 'This is the first announcement',
+      position: 1
+    });
+    announcementEqual(announcements.objectAt(1), {
+      description: 'This is the second announcement',
+      position: 2
+    });
+    announcementEqual(announcements.objectAt(2), {
+      description: 'This is the third announcement',
+      position: 3
+    });
   });
 });
+
+function announcementEqual(announcement, hash) {
+  Object.keys(hash).forEach(function(key) {
+    equal(announcement.get(key), hash[key]);
+  });
+}

--- a/tests/acceptance/routes/bulletins/new-test.js
+++ b/tests/acceptance/routes/bulletins/new-test.js
@@ -1,6 +1,7 @@
 import FactoryGuy from 'factory-guy';
 import { testMixin as FactoryGuyTestMixin } from 'factory-guy';
 import Ember from 'ember';
+import { moduleFor, test } from 'ember-qunit';
 import startApp from '../../../helpers/start-app';
 import { defineFixture } from 'ic-ajax';
 
@@ -9,7 +10,7 @@ var application,
     englishService,
     TestHelper = Ember.Object.createWithMixins(FactoryGuyTestMixin);
 
-module('Acceptance: Route - bulletins/new', {
+moduleFor('route:bulletins/new', 'BulletinsNewRoute', {
   needs: ['model:bulletin'],
   setup: function() {
     application = startApp();
@@ -18,7 +19,7 @@ module('Acceptance: Route - bulletins/new', {
       name: 'English Service',
       slug: 'english-service'
     });
-    defineFixture('/api/v1/announcements/latest', {
+    defineFixture('/api/v1/announcements/latest?group_id=' + englishService.id, {
       response: {
         "announcements": [
           {
@@ -55,17 +56,14 @@ module('Acceptance: Route - bulletins/new', {
 });
 
 test('it populates a default bulletin', function() {
-  expect(8);
+  expect(11);
 
   testHelper.handleFindQuery('group', ['slug'], [englishService]);
   visit('/english-service/bulletins/new');
 
   andThen(function() {
     var route = application.__container__.lookup('route:bulletins/new');
-
-    route.modelFor = function() {
-      return englishService;
-    };
+    route.store = testHelper.getStore();
 
     route.model().then(function(model) {
       // it defaults the bulletin name to Sunday Worship Service
@@ -74,16 +72,20 @@ test('it populates a default bulletin', function() {
       // it sets the group to English Service
       equal(model.get('group'), englishService);
 
+      // it populates bulletin with latest announcements
       var announcements = model.get('announcements');
       announcementEqual(announcements.objectAt(0), {
+        id: null,
         description: 'This is the first announcement',
         position: 1
       });
       announcementEqual(announcements.objectAt(1), {
+        id: null,
         description: 'This is the second announcement',
         position: 2
       });
       announcementEqual(announcements.objectAt(2), {
+        id: null,
         description: 'This is the third announcement',
         position: 3
       });

--- a/tests/acceptance/routes/bulletins/new-test.js
+++ b/tests/acceptance/routes/bulletins/new-test.js
@@ -9,7 +9,7 @@ var application,
     englishService,
     TestHelper = Ember.Object.createWithMixins(FactoryGuyTestMixin);
 
-module('Acceptance: /english-service/bulletins/new', {
+module('Acceptance: Route - bulletins/new', {
   needs: ['model:bulletin'],
   setup: function() {
     application = startApp();
@@ -55,40 +55,35 @@ module('Acceptance: /english-service/bulletins/new', {
 });
 
 test('it populates a default bulletin', function() {
-  expect(11);
+  expect(8);
 
   testHelper.handleFindQuery('group', ['slug'], [englishService]);
-  // visit('/english-service/bulletins/new');
+  visit('/english-service/bulletins/new');
 
   andThen(function() {
     var route = application.__container__.lookup('route:bulletins/new');
-    var tuesday = "2012-12-18T03:51:57-05:00";
 
-    route.modelFor = function(model) {
+    route.modelFor = function() {
       return englishService;
     };
 
-    route.model(tuesday).then(function(model) {
+    route.model().then(function(model) {
       // it defaults the bulletin name to Sunday Worship Service
       equal(model.get('name'), 'Sunday Worship Service');
 
       // it sets the group to English Service
       equal(model.get('group'), englishService);
 
-      // it copies the latest announcements for current bulletin
       var announcements = model.get('announcements');
       announcementEqual(announcements.objectAt(0), {
-        id: null,
         description: 'This is the first announcement',
         position: 1
       });
       announcementEqual(announcements.objectAt(1), {
-        id: null,
         description: 'This is the second announcement',
         position: 2
       });
       announcementEqual(announcements.objectAt(2), {
-        id: null,
         description: 'This is the third announcement',
         position: 3
       });

--- a/tests/unit/models/announcement-test.js
+++ b/tests/unit/models/announcement-test.js
@@ -1,0 +1,17 @@
+import {
+  moduleForModel,
+  test
+} from 'ember-qunit';
+
+moduleForModel('announcement', 'Announcement', {
+  // Specify the other units that are required for this test.
+  needs: ['model:bulletin', 'model:group']
+});
+
+test('descriptionHtml: converts markdown description into HTML', function() {
+  var description = 'this is **markdown**';
+  var descriptionHtml = '<p>this is <strong>markdown</strong></p>';
+  var model = this.subject({ description: description });
+
+  equal(model.get('descriptionHtml').trim(), descriptionHtml);
+});

--- a/tests/unit/models/bulletin-test.js
+++ b/tests/unit/models/bulletin-test.js
@@ -7,20 +7,15 @@ import {
 
 moduleForModel('bulletin', 'Bulletin', {
   // Specify the other units that are required for this test.
-  needs: ['model:group']
+  needs: ['model:group', 'model:announcement']
 });
 
 test('serviceOrderHtml: converts markdown serviceOrder into HTML', function() {
   expect(1);
-
-  var serviceOrder = '<div>this is markdown</div>';
-  var serviceOrderHtml = 'fake service order rendered in html';
+  var serviceOrder = 'this is **markdown**';
+  var serviceOrderHtml = '<p>this is <strong>markdown</strong></p>';
   var group = { slug: 'english-service', name: 'Service' };
   var model = this.subject({ serviceOrder: serviceOrder });
 
-  window.marked = function(markdown) {
-    return serviceOrderHtml;
-  };
-
-  equal(serviceOrderHtml, model.get('serviceOrderHtml'));
+  equal(model.get('serviceOrderHtml').trim(), serviceOrderHtml);
 });

--- a/tests/unit/models/group-test.js
+++ b/tests/unit/models/group-test.js
@@ -5,10 +5,17 @@ import {
 
 moduleForModel('group', 'Group', {
   // Specify the other units that are required for this test.
-  needs: ['model:bulletin']
+  needs: ['model:bulletin', 'model:announcement']
 });
 
-test('it stores the group name', function() {
-  var model = this.subject({ name: 'Test Group' });
+test('it stores the expected attributes', function() {
+  expect(2);
+
+  var model = this.subject({
+    name: 'Test Group',
+    slug: 'test-group'
+  });
+
   equal(model.get('name'), 'Test Group');
+  equal(model.get('slug'), 'test-group');
 });

--- a/tests/unit/utils/next-service-test.js
+++ b/tests/unit/utils/next-service-test.js
@@ -1,0 +1,29 @@
+import nextService from 'mcac/utils/next-service';
+
+module('nextService');
+
+// Replace this with your real tests.
+test('it returns the following Sunday at 9:30 Montreal Time', function() {
+  var result = nextService(new Date("2012-12-18T03:51:57-05:00"));
+  equal(result.toDate().getTime(),
+        new Date("2012-12-23T09:30:00-05:00").getTime());
+});
+
+
+test('it returns the following Sunday at 9:30 Montreal Time (DST)', function() {
+  var result = nextService(new Date("2012-10-14T09:32:00-04:00"));
+  equal(result.toDate().getTime(),
+        new Date("2012-10-21T09:30:00-04:00").getTime());
+});
+
+test('it returns the following Sunday when currently Sunday', function() {
+  var result = nextService(new Date("2012-12-23T09:32:00-05:00"));
+  equal(result.toDate().getTime(),
+        new Date("2012-12-30T09:30:00-05:00").getTime());
+});
+
+test('it returns the current Sunday when Sunday before 9:30am', function() {
+  var result = nextService(new Date("2012-12-23T09:29:00-05:00"));
+  equal(result.toDate().getTime(),
+        new Date("2012-12-23T09:30:00-05:00").getTime());
+});


### PR DESCRIPTION
When creating a new bulletin, we need to populate the bulletin model with the most recent bulletin's announcements.

 - [x] Create announcements model
  - [x] id
  - [x] postId
  - [x] bulletinId
  - [x] description
  - [x] postiion
 - [x] Create mock server endpoint @ `/api/v1/announcements/latest?group_id=#{group_id}`
 - [x] Add `announcements` to model hook of `NewBulletinsRoute`.


https://github.com/danielspaniel/ember-data-factory-guy