### PR TITLE
Add announcements to bulletins

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -23,6 +23,7 @@ app.import('bower_components/moment-timezone/builds/moment-timezone-with-data-20
 app.import('bower_components/bootstrap-markdown/js/bootstrap-markdown.js');
 app.import('bower_components/bootstrap-markdown/css/bootstrap-markdown.min.css');
 app.import('bower_components/marked/lib/marked.js');
+app.import('bower_components/html.sortable/dist/html.sortable.min.js');
 
 var mergeTrees = require('broccoli-merge-trees');
 var pickFiles = require('broccoli-static-compiler');

--- a/app/components/announcement-editor.js
+++ b/app/components/announcement-editor.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  actions: {
+    addAnnouncement: function() {
+      this.sendAction('add-announcement', this.position);
+    },
+    removeAnnouncement: function() {
+      this.sendAction('remove-announcement', this.position - 1);
+    }
+  }
+});

--- a/app/components/announcements-editor.js
+++ b/app/components/announcements-editor.js
@@ -1,0 +1,27 @@
+import Ember from 'ember';
+
+function syncPositions(announcements) {
+  var i = 1;
+  announcements.forEach(function(announcement) {
+    announcement.set('position', i++);
+  });
+}
+
+export default Ember.Component.extend({
+  actions: {
+    addAnnouncement: function(index) {
+      var announcements = this.get('announcements');
+      var store = this.get('targetObject').store;
+      announcements.insertAt(index, store.createRecord('announcement', {}));
+      syncPositions(announcements);
+    },
+    removeAnnouncement: function(index) {
+      var announcements = this.get('announcements');
+      announcements.removeAt(index);
+      syncPositions(announcements);
+    }
+  },
+  makeDraggable: function() {
+    Ember.$('#announcements-editor', this.element).sortable();
+  }.on('didInsertElement')
+});

--- a/app/controllers/bulletins/new/announcements.js
+++ b/app/controllers/bulletins/new/announcements.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+});

--- a/app/router.js
+++ b/app/router.js
@@ -1,20 +1,22 @@
-import Ember from 'ember';
-import config from './config/environment';
+import Ember from "ember";
+import config from "./config/environment";
 
 var Router = Ember.Router.extend({
   location: config.locationType
 });
 
 Router.map(function() {
-  this.resource('group', { path: ':group_slug' }, function() {
-    this.resource('bulletin', { path: 'bulletins/:bulletin_id' }, function() {
-    });
+  this.resource("group", { path: ":group_slug" }, function() {
+    this.resource("bulletin", { path: "bulletins/:bulletin_id" }, function() {});
 
-    this.resource('bulletins', { path: 'bulletins' }, function() {
-      this.route('new');
+    this.resource("bulletins", { path: "bulletins" }, function() {
+      this.route("new", function() {
+        this.route("announcements");
+      });
     });
   });
-  this.route('bulletin/sunday', { path: '/sunday' }, function() {
+
+  this.route("bulletin/sunday", { path: "/sunday" }, function() {
   });
 });
 

--- a/app/routes/bulletins/new/announcements.js
+++ b/app/routes/bulletins/new/announcements.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -1,0 +1,5 @@
+$light-gray: #ddd;
+
+$padding-s: 2px;
+$padding-m: 10px;
+$padding-l: 25px;

--- a/app/styles/announcement-editor.scss
+++ b/app/styles/announcement-editor.scss
@@ -1,0 +1,23 @@
+@import 'variables.scss';
+
+textarea.announcement-editor {
+  width: 100%;
+  border: none;
+}
+
+#announcements-editor {
+  .sortable-placeholder {
+    height: 60px;
+    border-style: dashed;
+    border-width: $padding-s;
+    border-color: $light-gray;
+    padding: $padding-m;
+  }
+
+  .sortable-dragging {
+  }
+
+  li.draggable-announcement {
+    cursor: ns-resize;
+  }
+}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,3 +1,1 @@
-html, body {
-  margin: 20px;
-}
+@import 'announcement-editor';

--- a/app/templates/bulletins/new.hbs
+++ b/app/templates/bulletins/new.hbs
@@ -19,7 +19,10 @@
                           class="form-control"
                           rows="10"}}
     </div>
-    <button type="submit" {{action 'save'}} class="btn btn-default">
+    <div class="form-group">
+    {{#link-to 'bulletins.new.announcements' class='btn btn-default'}}Add announcements{{/link-to}}
+    </div>
+    <button type="submit" {{action 'save'}} class="btn btn-primary">
       Save
     </button>
   </form>

--- a/app/templates/bulletins/new/announcements.hbs
+++ b/app/templates/bulletins/new/announcements.hbs
@@ -1,0 +1,2 @@
+<h1>Announcements</h1>
+{{outlet}}

--- a/app/templates/bulletins/new/announcements.hbs
+++ b/app/templates/bulletins/new/announcements.hbs
@@ -1,2 +1,5 @@
 <h1>Announcements</h1>
+
+{{announcements-editor announcements=model.announcements}}
+
 {{outlet}}

--- a/app/templates/components/announcement-editor.hbs
+++ b/app/templates/components/announcement-editor.hbs
@@ -1,0 +1,14 @@
+{{textarea placeholder="Enter announcement description..."
+           class="announcement-editor"
+           value=description}}
+
+<button {{action 'addAnnouncement'}} class="btn btn-default add-announcement">
+  Add
+</button>
+
+<button {{action 'removeAnnouncement'}}
+        class="btn btn-danger remove-announcement">
+  Remove
+</button>
+
+{{yield}}

--- a/app/templates/components/announcements-editor.hbs
+++ b/app/templates/components/announcements-editor.hbs
@@ -1,0 +1,11 @@
+<ol id="announcements-editor">
+  {{#each announcement in announcements}}
+    <li class="draggable-announcement">
+      {{announcement-editor description=announcement.description
+                            position=announcement.position
+                            add-announcement="addAnnouncement"
+                            remove-announcement="removeAnnouncement"}}
+    </li>
+  {{/each}}
+</ul>
+{{yield}}

--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,7 @@
     "moment-timezone": "~0.2.5",
     "bootstrap-markdown": "~2.8.0",
     "marked": "~0.3.2",
-    "ember-data-factory-guy": "~0.9.4"
+    "ember-data-factory-guy": "~0.9.4",
+    "html.sortable": "~0.1.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "broccoli-asset-rev": "^2.0.0",
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
     "broccoli-merge-trees": "^0.2.1",
+    "broccoli-sass": "^0.3.3",
     "broccoli-static-compiler": "^0.2.1",
     "connect-restreamer": "^1.0.1",
     "ember-bootstrap-datetimepicker": "^0.2.7",

--- a/tests/fixtures/announcement.js
+++ b/tests/fixtures/announcement.js
@@ -1,0 +1,16 @@
+import FactoryGuy from 'factory-guy';
+
+FactoryGuy.define('announcement', {
+  sequences: {
+    position: function(num) {
+      return num;
+    }
+  },
+  default: {
+    bulletin: FactoryGuy.belongsTo('bulletin'),
+    position: FactoryGuy.generate('position'),
+    description: 'This is a description'
+  }
+});
+
+export default {};

--- a/tests/unit/components/announcement-editor-test.js
+++ b/tests/unit/components/announcement-editor-test.js
@@ -1,0 +1,59 @@
+import Ember from 'ember';
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+import startApp from '../../helpers/start-app';
+
+var application;
+
+moduleForComponent('announcement-editor', 'AnnouncementEditorComponent', {
+  // specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar']
+  setup: function() {
+    application = startApp();
+  },
+  teardown: function() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test('it sends the correct actions when buttons are clicked', function() {
+  expect(2);
+
+  var component = this.subject(),
+      $component = this.append(),
+      targetObject = {
+        add: function(index) {
+          // it sends 'add-announcement' action with 0-based index
+          equal(index, 1);
+        },
+        remove: function(index) {
+          // it sends 'remove-announcement' action with 0-based index
+          equal(index, 0);
+        }
+      };
+
+  Ember.run(function() {
+    component.set('position', 1);
+    component.set('description', 'this is a description');
+    component.set('targetObject', targetObject);
+    component.set('add-announcement', 'add');
+    component.set('remove-announcement', 'remove');
+  });
+
+  click('.add-announcement');
+  click('.remove-announcement');
+});
+
+test('it renders', function() {
+  expect(2);
+
+  // creates the component instance
+  var component = this.subject();
+  equal(component._state, 'preRender');
+
+  // appends the component to the page
+  this.append();
+  equal(component._state, 'inDOM');
+});

--- a/tests/unit/components/announcements-editor-test.js
+++ b/tests/unit/components/announcements-editor-test.js
@@ -1,0 +1,84 @@
+import FactoryGuy from 'factory-guy';
+import { testMixin as FactoryGuyTestMixin } from 'factory-guy';
+import Ember from 'ember';
+import { moduleForComponent, test } from 'ember-qunit';
+import startApp from '../../helpers/start-app';
+
+var application,
+    testHelper,
+    englishService,
+    component,
+    TestHelper = Ember.Object.createWithMixins(FactoryGuyTestMixin);
+
+moduleForComponent('announcements-editor', 'AnnouncementsEditorComponent', {
+  needs: [
+    'model:bulletin',
+    'component:announcement-editor',
+    'template:components/announcement-editor'
+  ],
+  setup: function() {
+    application = startApp();
+    testHelper = TestHelper.setup(application);
+  },
+  teardown: function() {
+    Ember.run(function() {
+      testHelper.teardown();
+    });
+    Ember.run(application, 'destroy');
+  }
+});
+
+test('addAnnouncement - it adds announcement below the current announcement', function() {
+  expect(2);
+
+  var component = this.subject(),
+      $component = this.append(),
+      targetObject = {
+        store: testHelper.getStore(),
+        model: testHelper.make('bulletin')
+      };
+
+  Ember.run(function() {
+    component.set('announcements', targetObject.model.get('announcements'));
+    component.set('targetObject', targetObject);
+    targetObject.model.get('announcements').
+                       addObjects(FactoryGuy.makeList('announcement', 3));
+  });
+
+  var announcements = targetObject.model.get('announcements');
+
+  click('#announcements-editor li:first button.add-announcement');
+
+  andThen(function() {
+    equal(announcements.objectAt(1).get('id'), null);
+    equal(announcements.get('length'), 4);
+  });
+});
+
+test('removeAnnouncement - it removes announcement at index specified', function() {
+  expect(2);
+
+  var component = this.subject(),
+      $component = this.append(),
+      targetObject = {
+        store: testHelper.getStore(),
+        model: testHelper.make('bulletin')
+      };
+
+  Ember.run(function() {
+    component.set('announcements', targetObject.model.get('announcements'));
+    component.set('targetObject', targetObject);
+    targetObject.model.get('announcements').
+                       addObjects(FactoryGuy.makeList('announcement', 3));
+  });
+
+  var announcements = targetObject.model.get('announcements');
+  var secondAnnouncementId = announcements.objectAt(1).get('id');
+
+  click('#announcements-editor li:first button.remove-announcement');
+
+  andThen(function() {
+    equal(announcements.objectAt(0).get('id'), secondAnnouncementId);
+    equal(announcements.get('length'), 2);
+  });
+});

--- a/tests/unit/routes/bulletins/new/announcements-test.js
+++ b/tests/unit/routes/bulletins/new/announcements-test.js
@@ -1,0 +1,14 @@
+import {
+  moduleFor,
+  test
+} from 'ember-qunit';
+
+moduleFor('route:bulletins/new/announcements', 'BulletinsNewAnnouncementsRoute', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function() {
+  var route = this.subject();
+  ok(route);
+});


### PR DESCRIPTION
![announcements-add](https://cloud.githubusercontent.com/assets/549222/5698915/c4b716ec-99e7-11e4-976a-ccdca7fef43b.png)

 - [x] Add route to create announcements for new bulletins at `/:group-slug/bulletins/new/announcements`
 - [x] Add link to new bulletin form to link to announcements form
 - [ ] Add back button to bring user back to bulletin form
 - [x] #32 Create component to render a draggable announcement: `{{announcement-editor}}`
 - [x] Render a list of `{{announcement-editor}}` for every `announcement` in `bulletin.announcements`