### PR TITLE
Avoid deadlock when saving announcements

### DIFF
--- a/app/controllers/bulletin/edit.js
+++ b/app/controllers/bulletin/edit.js
@@ -6,12 +6,10 @@ export default Ember.ObjectController.extend({
       var _this = this;
       var bulletin = _this.get('model');
       bulletin.set('publishedAt', moment(bulletin.get('publishedAt')).toDate());
-      bulletin.save().then(function(savedBulletin) {
-        console.log('saved bulletin: ' + savedBulletin.get('id'));
-      });
-
-      bulletin.get('announcements').then(function(announcements) {
-        announcements.save();
+      bulletin.save().then(function() {
+        bulletin.get('announcements').then(function(announcements) {
+          announcements.save();
+        });
       });
     }
   }

--- a/tests/acceptance/bulletins/edit-test.js
+++ b/tests/acceptance/bulletins/edit-test.js
@@ -122,13 +122,6 @@ test('saving a bulletin', function() {
         return [200, {"Content-Type": "application/vnd.api+json"}, all];
       });
 
-      this.get('/api/v1/announcements', function(request) {
-        if (request.queryParams.latest_for_group === '1') {
-          var response = { "announcements": [] };
-          return [200, {"Content-Type": "application/vnd.api+json"}, JSON.stringify(response)];
-        }
-      });
-
       this.put('/api/v1/bulletins/1', function(request) {
         updatedBulletin = JSON.parse(request.requestBody);
         return [200, {"Content-Type": "application/vnd.api+json"}, JSON.stringify(updatedBulletin)];
@@ -158,7 +151,7 @@ test('saving a bulletin', function() {
   fillIn('.bulletin-name', 'Updated bulletin name');
   fillIn('.description', 'Updated description');
   fillIn('.service-order', 'Updated service order');
-  click(':submit');
+  click('.save-bulletin');
 
   andThen(function() {
     equal(updatedBulletin.bulletins.name, 'Updated bulletin name');


### PR DESCRIPTION
Only save announcements after a bulletin has been successfully saved.