### PR TITLE
Staging application deployment

### DIFF
--- a/config/deploy.js
+++ b/config/deploy.js
@@ -1,0 +1,20 @@
+/* jshint node: true */
+
+module.exports = {
+  staging: {
+    store: {
+      type: 'redis',
+      host: 'staging.mcac.church',
+      port: 6379
+    },
+    assets: {
+      gzip: false,
+      type: 'rsync',
+      dest: 'deploy@staging.mcac.church:~/apps/mcac-js',
+      ssh: true,
+      port: 22,
+      privateKey: '~/.ssh/id_rsa',
+      args: ['-av']
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "ember-cli-content-security-policy": "0.3.0",
     "ember-cli-data-factory-guy": "^0.9.0",
     "ember-cli-dependency-checker": "0.0.7",
+    "ember-cli-deploy": "^0.4.1",
+    "ember-cli-deploy-rsync": "0.0.1",
     "ember-cli-htmlbars": "^0.6.0",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
@@ -39,12 +41,13 @@
     "ember-cli-qunit": "0.3.1",
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.15",
+    "ember-deploy-redis": "0.0.2",
     "ember-export-application-global": "^1.0.0",
     "ember-json-api": "achan/ember-json-api#ac_remove_hasMany_on_create",
     "ember-marked": "0.0.4",
     "express": "^4.8.5",
     "glob": "^4.0.5",
     "morgan": "^1.5.1",
-    "rimraf":"2.2.8"
+    "rimraf": "2.2.8"
   }
 }


### PR DESCRIPTION
```bash
$ ember deploy --environment staging
```

Currently saves the index in redis, but is not used.