### PR TITLE
Populate service order from latest bulletin

### DIFF
--- a/app/routes/bulletin/edit.js
+++ b/app/routes/bulletin/edit.js
@@ -2,4 +2,39 @@ import AuthenticatedRouteMixin from 'simple-auth/mixins/authenticated-route-mixi
 import Ember from 'ember';
 
 export default Ember.Route.extend(AuthenticatedRouteMixin, {
+  model: function() {
+    var model = this.modelFor('bulletin');
+
+    if (hasNoAnnouncements(model)) {
+      populateLatestAnnouncements(model, this.store);
+    }
+
+    return model;
+  }
 });
+
+function populateLatestAnnouncements(bulletin, store) {
+  var group = bulletin.get('group');
+  store.find('announcement', { latest_for_group: group.get('id') }).
+        then(function(announcements) {
+    copyAnnouncementsIntoBulletin(store, announcements, bulletin);
+  });
+}
+
+function copyAnnouncementsIntoBulletin(store, announcements, bulletin) {
+  announcements.forEach(function(announcement) {
+    bulletin.get('announcements').
+             addObject(cloneAnnouncement(store, announcement));
+  });
+}
+
+function cloneAnnouncement(store, announcement) {
+  return store.createRecord('announcement', {
+    description: announcement.get('description'),
+    position: announcement.get('position')
+  });
+}
+
+function hasNoAnnouncements(bulletin) {
+  return bulletin.get('announcements').get('length') === 0;
+}

--- a/app/routes/bulletins/new.js
+++ b/app/routes/bulletins/new.js
@@ -11,8 +11,16 @@ export default Ember.Route.extend({
       publishedAt: publishedAt.toDate(),
       name: 'Sunday Worship Service',
       description: publishedAt.format('MMMM Do YYYY, h:mm a'),
-      serviceOrder: 'Default service order',
+      serviceOrder: '',
       group: group
+    });
+
+    _this.store.find('bulletin', { latest_for_group: group.get('id') }).
+                then(function(bulletins) {
+      if (bulletins.get('length') === 0) { return; }
+
+      defaultBulletin.set('serviceOrder',
+                          bulletins.get('firstObject').get('serviceOrder'));
     });
 
     return defaultBulletin;

--- a/server/mocks/bulletins.js
+++ b/server/mocks/bulletins.js
@@ -18,9 +18,13 @@ module.exports = function(app) {
   }];
 
   bulletinsRouter.get('/', function(req, res) {
-    res.send({
-      "bulletins": db,
-    });
+    if (req.query.latest_for_group) {
+      res.send({ bulletins: [db[db.length - 1]] });
+    } else {
+      res.send({
+        "bulletins": db,
+      });
+    }
   });
 
   bulletinsRouter.post('/', function(req, res) {

--- a/tests/acceptance/bulletins/new-test.js
+++ b/tests/acceptance/bulletins/new-test.js
@@ -4,7 +4,7 @@ import startApp from '../../helpers/start-app';
 import nextService from 'mcac/utils/next-service';
 import Pretender from 'pretender';
 
-var application;
+var application, server;
 
 var englishService = {
   "id": "1",
@@ -15,33 +15,40 @@ var englishService = {
 
 var groups = { "groups": [englishService] };
 
+function createServer() {
+  return new Pretender(function() {
+    this.get('/api/v1/groups', function(request) {
+      var all = JSON.stringify(groups);
+      return [200, {"Content-Type": "application/vnd.api+json"}, all];
+    });
+
+  });
+}
+
 module('Acceptance: New bulletin form', {
   needs: ['model:bulletin', 'model:group'],
   setup: function() {
     application = startApp();
+    server = createServer();
   },
   teardown: function() {
+    server.shutdown();
     Ember.run(application, 'destroy');
   }
 });
 
-test('visiting /english-service/bulletins/new', function(assert) {
+test('default bulletin values without a previous bulletin', function(assert) {
   assert.expect(3);
 
-  Ember.run(function() {
-    var server = new Pretender(function() {
-      this.get('/api/v1/groups', function(request) {
-        var all = JSON.stringify(groups);
-        return [200, {"Content-Type": "application/vnd.api+json"}, all];
-      });
-
-      this.get('/api/v1/announcements', function(request) {
-        if (request.queryParams.latest_for_group === '1') {
-          var response = { "announcements": [] };
-          return [200, {"Content-Type": "application/vnd.api+json"}, JSON.stringify(response)];
-        }
-      });
-    });
+  server.get('/api/v1/bulletins', function(request) {
+    if (request.queryParams.latest_for_group === '1') {
+      var response = { bulletins: [] };
+      return [
+        200,
+        {"Content-Type": "application/vnd.api+json"},
+        JSON.stringify(response)
+      ];
+    }
   });
 
   visit('/english-service/bulletins/new');
@@ -49,7 +56,38 @@ test('visiting /english-service/bulletins/new', function(assert) {
   andThen(function() {
     assert.equal(find('.bulletin-name').val(), 'Sunday Worship Service');
     equalDate(assert, find('.published-at input').val(), nextService());
-    assert.equal(find('.service-order').val(), 'Default service order');
+    assert.equal(find('.service-order').val(), '');
+  });
+});
+
+test("defaults with last week's service order if available", function(assert) {
+  assert.expect(1);
+
+  server.get('/api/v1/bulletins', function(request) {
+    if (request.queryParams.latest_for_group === '1') {
+      var response = {
+        "bulletins": [{
+          "id": "1",
+          "serviceOrder": "Last week's service order",
+          "links": {
+            "group": "1",
+            "announcements": []
+          }
+        }]
+      };
+
+      return [
+        200,
+        {"Content-Type": "application/vnd.api+json"},
+        JSON.stringify(response)
+      ];
+    }
+  });
+
+  visit('/english-service/bulletins/new');
+
+  andThen(function() {
+    assert.equal(find('.service-order').val(), "Last week's service order");
   });
 });
 
@@ -58,39 +96,39 @@ test('saving a bulletin navigates to edit page', function(assert) {
 
   authenticateSession();
 
-  Ember.run(function() {
-    var server = new Pretender(function() {
-      this.get('/api/v1/groups', function(request) {
-        if (request.queryParams.slug === 'english-service') {
-          var all = JSON.stringify(groups);
-          return [200, {"Content-Type": "application/vnd.api+json"}, all];
-        }
-      });
+  server.get('/api/v1/bulletins', function(request) {
+    if (request.queryParams.latest_for_group === '1') {
+      var response = { bulletins: [] };
+      return [
+        200,
+        {"Content-Type": "application/vnd.api+json"},
+        JSON.stringify(response)
+      ];
+    }
+  });
 
-      this.get('/api/v1/announcements', function(request) {
-        if (request.queryParams.latest_for_group === '1') {
-          var response = { "announcements": [] };
-          return [200, {"Content-Type": "application/vnd.api+json"}, JSON.stringify(response)];
-        }
-      });
+  server.get('/api/v1/announcements', function(request) {
+    if (request.queryParams.latest_for_group === '1') {
+      var response = { "announcements": [] };
+      return [200, {"Content-Type": "application/vnd.api+json"}, JSON.stringify(response)];
+    }
+  });
 
-      this.post('/api/v1/bulletins', function(request) {
-        var response = {
-          "bulletins": {
-            "id": "1",
-            "description": "This is a service bulletin.",
-            "name": "Sunday Service",
-            "serviceOrder": "This is the service order.",
-            "publishedAt": "2015-03-07T03:58:40+00:00",
-            "links": {
-              "group": "1",
-              "announcements": []
-            }
-          }
-        };
-        return [200, {"Content-Type": "application/vnd.api+json"}, JSON.stringify(response)];
-      });
-    });
+  server.post('/api/v1/bulletins', function(request) {
+    var response = {
+      "bulletins": {
+        "id": "2",
+        "description": "This is a service bulletin.",
+        "name": "Sunday Service",
+        "serviceOrder": "This is the service order.",
+        "publishedAt": "2015-03-07T03:58:40+00:00",
+        "links": {
+          "group": "1",
+          "announcements": []
+        }
+      }
+    };
+    return [200, {"Content-Type": "application/vnd.api+json"}, JSON.stringify(response)];
   });
 
   visit('/english-service/bulletins/new');
@@ -98,7 +136,7 @@ test('saving a bulletin navigates to edit page', function(assert) {
   click(':submit');
 
   andThen(function() {
-    assert.equal(currentURL(), '/english-service/bulletins/1/edit');
+    assert.equal(currentURL(), '/english-service/bulletins/2/edit');
   });
 });
 


### PR DESCRIPTION
Populate the following information from the latest bulletin:

 - [x] Service order when creating a new bulletin
 - [x] Announcements when editing a bulletin with no announcements