### PR TITLE
Reordering announcements

### DIFF
--- a/app/components/announcements-editor.js
+++ b/app/components/announcements-editor.js
@@ -24,11 +24,14 @@ export default Ember.Component.extend({
       syncPositions(announcements);
     }
   },
+  onAnnouncementChange: function() {
+    Ember.run.later(this, 'makeDraggable');
+  }.observes('announcements'),
   makeDraggable: function() {
     Ember.$('#announcements-editor', this.element).
           sortable().
           bind('sortupdate', onAnnouncementDragged(this));
-  }.on('didInsertElement')
+  }
 });
 
 function onAnnouncementDragged(context) {

--- a/app/components/announcements-editor.js
+++ b/app/components/announcements-editor.js
@@ -1,12 +1,5 @@
 import Ember from 'ember';
 
-function syncPositions(announcements) {
-  var i = 1;
-  announcements.forEach(function(announcement) {
-    announcement.set('position', i++);
-  });
-}
-
 export default Ember.Component.extend({
   actions: {
     addAnnouncement: function(index) {
@@ -32,6 +25,31 @@ export default Ember.Component.extend({
     }
   },
   makeDraggable: function() {
-    Ember.$('#announcements-editor', this.element).sortable();
+    Ember.$('#announcements-editor', this.element).
+          sortable().
+          bind('sortupdate', onAnnouncementDragged(this));
   }.on('didInsertElement')
 });
+
+function onAnnouncementDragged(context) {
+  return function(e, ui) {
+    saveDraggedAnnouncementPosition(context, ui);
+  };
+}
+
+function saveDraggedAnnouncementPosition(context, ui) {
+  var announcement = getDraggedAnnouncement(context.get('announcements'), ui);
+  announcement.set('position', ui.item.index() + 1);
+  announcement.save();
+}
+
+function getDraggedAnnouncement(announcements, ui) {
+  return announcements.findBy('id', `${ui.item.data('id')}`);
+}
+
+function syncPositions(announcements) {
+  var i = 1;
+  announcements.forEach(function(announcement) {
+    announcement.set('position', i++);
+  });
+}

--- a/app/components/announcements-editor.js
+++ b/app/components/announcements-editor.js
@@ -18,10 +18,7 @@ export default Ember.Component.extend({
       });
     },
     appendAnnouncement: function() {
-      var announcements = this.get('announcements');
-      var store = this.get('targetObject').store;
-      announcements.pushObject(store.createRecord('announcement', {}));
-      syncPositions(announcements);
+      this.sendAction('append-announcement');
     }
   },
   onAnnouncementChange: function() {

--- a/app/components/announcements-editor.js
+++ b/app/components/announcements-editor.js
@@ -6,14 +6,15 @@ export default Ember.Component.extend({
       var announcements = this.get('announcements');
       var store = this.get('targetObject').store;
       announcements.insertAt(index, store.createRecord('announcement', {}));
-      syncPositions(announcements);
+      syncPositions(this);
     },
     removeAnnouncement: function(index) {
-      var announcements = this.get('announcements');
+      var _this = this;
+      var announcements = _this.get('announcements');
       var announcement = announcements.objectAt(index);
       Pace.restart();
       announcement.destroyRecord().then(function() {
-        syncPositions(announcements);
+        syncPositions(_this);
         Pace.stop();
       });
     },
@@ -36,8 +37,7 @@ export default Ember.Component.extend({
 function onAnnouncementDraggedFn(context) {
   return function(e, ui) {
     saveDraggedAnnouncementPosition(context, ui.item);
-    syncPositions(context.get('announcements'));
-    Ember.run.later(context, 'makeDraggable', 1000);
+    syncPositions(context);
   };
 }
 
@@ -48,13 +48,16 @@ function saveDraggedAnnouncementPosition(context, $item) {
   announcement.save();
 }
 
-function syncPositions(announcements) {
+function syncPositions(context) {
+  var announcements = context.get('announcements');
   announcements.beginPropertyChanges();
 
   Ember.$('#announcements-editor .draggable-announcement').
         each(syncAnnouncementFn(announcements));
 
   announcements.endPropertyChanges();
+
+  Ember.run.later(context, 'makeDraggable', 1000);
 }
 
 function syncAnnouncementFn(announcements) {

--- a/app/components/announcements-editor.js
+++ b/app/components/announcements-editor.js
@@ -29,22 +29,22 @@ export default Ember.Component.extend({
         Ember.$('#announcements-editor', this.element);
     $announcementsEditor.sortable('destroy');
     $announcementsEditor.sortable().
-                         bind('sortupdate', onAnnouncementDragged(this));
+                         bind('sortupdate', onAnnouncementDraggedFn(this));
   }
 });
 
-function onAnnouncementDragged(context) {
+function onAnnouncementDraggedFn(context) {
   return function(e, ui) {
-    saveDraggedAnnouncementPosition(context, ui);
+    saveDraggedAnnouncementPosition(context, ui.item);
     syncPositions(context.get('announcements'));
     Ember.run.later(context, 'makeDraggable', 1000);
   };
 }
 
-function saveDraggedAnnouncementPosition(context, ui) {
+function saveDraggedAnnouncementPosition(context, $item) {
   var announcement = getDraggedAnnouncement(context.get('announcements'),
-                                            ui.item.data('id'));
-  announcement.set('position', ui.item.index() + 1);
+                                            $item.data('id'));
+  announcement.set('position', $item.index() + 1);
   announcement.save();
 }
 
@@ -52,13 +52,17 @@ function syncPositions(announcements) {
   announcements.beginPropertyChanges();
 
   Ember.$('#announcements-editor .draggable-announcement').
-        each(function(index, domAnnouncement) {
+        each(syncAnnouncementFn(announcements));
+
+  announcements.endPropertyChanges();
+}
+
+function syncAnnouncementFn(announcements) {
+  return function(index, domAnnouncement) {
     var announcement =
         getDraggedAnnouncement(announcements, Ember.$(domAnnouncement).data('id'));
     announcement.set('position', index+1);
-  });
-
-  announcements.endPropertyChanges();
+  };
 }
 
 function getDraggedAnnouncement(announcements, announcementId) {

--- a/app/controllers/bulletin/edit.js
+++ b/app/controllers/bulletin/edit.js
@@ -2,6 +2,11 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   actions: {
+    appendAnnouncement: function() {
+      var bulletin = this.get('model');
+      var announcements = bulletin.get('announcements');
+      announcements.pushObject(this.store.createRecord('announcement', { position: announcements.get('length') + 1 }));
+    },
     save: function() {
       var _this = this;
       var bulletin = _this.get('model');

--- a/app/models/bulletin.js
+++ b/app/models/bulletin.js
@@ -9,5 +9,8 @@ export default DS.Model.extend({
   announcements: DS.hasMany('announcement', { async: true }),
   serviceOrderHtml: function() {
     return marked(this.get('serviceOrder'));
-  }.property('serviceOrder')
+  }.property('serviceOrder'),
+  sortedAnnouncements: function() {
+    return this.get('announcements').sortBy('position');
+  }.property('announcements.@each.position')
 });

--- a/app/templates/bulletin/edit.hbs
+++ b/app/templates/bulletin/edit.hbs
@@ -41,7 +41,8 @@
 
       <section class="announcements col-md-6">
         <h3>Announcements</h3>
-        {{announcements-editor announcements=model.sortedAnnouncements}}
+        {{announcements-editor announcements=model.sortedAnnouncements
+                               append-announcement="appendAnnouncement"}}
       </section>
     </div>
   </form>

--- a/app/templates/bulletin/edit.hbs
+++ b/app/templates/bulletin/edit.hbs
@@ -41,7 +41,7 @@
 
       <section class="announcements col-md-6">
         <h3>Announcements</h3>
-        {{announcements-editor announcements=model.announcements}}
+        {{announcements-editor announcements=model.sortedAnnouncements}}
       </section>
     </div>
   </form>

--- a/app/templates/bulletin/sunday/index.hbs
+++ b/app/templates/bulletin/sunday/index.hbs
@@ -15,7 +15,7 @@
           </section>
           <section class="col-sm-6 announcements">
             <ol>
-              {{#each model.announcements as |announcement|}}
+              {{#each model.sortedAnnouncements as |announcement|}}
               <li>{{{announcement.descriptionHtml}}}</li>
               {{else}}
               <li>No announcements yet</li>

--- a/app/templates/components/announcement-editor.hbs
+++ b/app/templates/components/announcement-editor.hbs
@@ -11,4 +11,6 @@
   Remove
 </button>
 
+{{position}}
+
 {{yield}}

--- a/app/templates/components/announcements-editor.hbs
+++ b/app/templates/components/announcements-editor.hbs
@@ -5,7 +5,7 @@
 
 <ol id="announcements-editor">
   {{#each announcements as |announcement|}}
-    <li class="draggable-announcement">
+    <li class="draggable-announcement" data-id="{{announcement.id}}">
       {{announcement-editor description=announcement.description
                             position=announcement.position
                             announcement-id=announcement.id


### PR DESCRIPTION
A rethink of reordering announcements.

The bulletin announcements are now sorted from the model and passed into the `AnnouncementsEditor` sorted. The announcements are then handled as a regular array within the editor.

The announcements editor is also made draggable in a separate run loop since it was causing race conditions.