### PR TITLE
Save announcements sequentially

### DIFF
--- a/app/controllers/bulletin/edit.js
+++ b/app/controllers/bulletin/edit.js
@@ -13,12 +13,23 @@ export default Ember.Controller.extend({
       bulletin.set('publishedAt', moment(bulletin.get('publishedAt')).toDate());
       Pace.restart();
       bulletin.save().then(function() {
-        bulletin.get('announcements').then(function(announcements) {
-          announcements.save().then(function() {
-            Pace.stop();
-          });
-        });
+        saveNextAnnouncement(bulletin);
       });
     }
   }
 });
+
+function saveNextAnnouncement(bulletin) {
+  function next() {
+    saveNextAnnouncement(bulletin);
+  }
+
+  var unsavedAnnouncement =
+    bulletin.get('unsavedAnnouncements').get('firstObject');
+
+  if (unsavedAnnouncement) {
+    unsavedAnnouncement.save().then(next);
+  } else {
+    Pace.stop();
+  }
+}

--- a/app/models/bulletin.js
+++ b/app/models/bulletin.js
@@ -12,5 +12,8 @@ export default DS.Model.extend({
   }.property('serviceOrder'),
   sortedAnnouncements: function() {
     return this.get('announcements').sortBy('position');
-  }.property('announcements.@each.position')
+  }.property('announcements.@each.position'),
+  unsavedAnnouncements: function() {
+    return this.get('sortedAnnouncements').filterBy('isDirty');
+  }.property('sortedAnnouncements.@each.isDirty')
 });


### PR DESCRIPTION
Due to the backend implementation we must save announcements sequentially in order to preserve announcement positions.