### PR TITLE
Prevent bulletin from scrolling horizontally

### DIFF
--- a/app/styles/components/bulletin-cover.scss
+++ b/app/styles/components/bulletin-cover.scss
@@ -51,7 +51,7 @@
     text-align: left;
 
     .inner {
-      margin-left: $padding-xl;
+      padding-left: $padding-xl;
     }
 
     .name {


### PR DESCRIPTION
Replace margin with padding so that the contents stay within its container.