### PR TITLE
Maintain banner aspect ratio

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -25,3 +25,5 @@ $extra-large-device-break: 1200px;
 
 $nav-bar-height: 50px;
 $bulletin-announcements-color: $gray-blue-light;
+
+$banner-ratio: 28.125%;

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -26,4 +26,5 @@ $extra-large-device-break: 1200px;
 $nav-bar-height: 50px;
 $bulletin-announcements-color: $gray-blue-light;
 
-$banner-ratio: 28.125%;
+$group-banner-ratio: percentage(9/32);
+$post-banner-ratio: percentage(9/21);

--- a/app/styles/components/group-header.scss
+++ b/app/styles/components/group-header.scss
@@ -40,7 +40,7 @@
     background-position: center;
     background-size: cover;
     color: $white;
-    padding: 75px $padding-l $padding-l $padding-l;
+    padding: 28.125% $padding-l $padding-l $padding-l;
     position: relative;
 
     a {

--- a/app/styles/components/group-header.scss
+++ b/app/styles/components/group-header.scss
@@ -40,7 +40,7 @@
     background-position: center;
     background-size: cover;
     color: $white;
-    padding: 28.125% $padding-l $padding-l $padding-l;
+    padding: $banner-ratio $padding-l $padding-l $padding-l;
     position: relative;
 
     a {

--- a/app/styles/components/group-header.scss
+++ b/app/styles/components/group-header.scss
@@ -40,7 +40,7 @@
     background-position: center;
     background-size: cover;
     color: $white;
-    padding: $banner-ratio $padding-l $padding-l $padding-l;
+    padding: $group-banner-ratio $padding-l $padding-l $padding-l;
     position: relative;
 
     a {

--- a/app/styles/components/post-view.scss
+++ b/app/styles/components/post-view.scss
@@ -15,7 +15,7 @@
     background-size: cover;
     color: $white;
     margin: $padding-m -15px 0 -15px;
-    padding: $banner-ratio $padding-l $padding-l $padding-l;
+    padding: $post-banner-ratio $padding-l $padding-l $padding-l;
     position: relative;
   }
 

--- a/app/styles/components/post-view.scss
+++ b/app/styles/components/post-view.scss
@@ -15,7 +15,7 @@
     background-size: cover;
     color: $white;
     margin: $padding-m -15px 0 -15px;
-    padding: 110px $padding-l $padding-l $padding-l;
+    padding: $banner-ratio $padding-l $padding-l $padding-l;
     position: relative;
   }
 
@@ -82,8 +82,6 @@
   }
 
   .banner {
-    padding-top: 200px;
-
     img {
       width: 100%;
     }
@@ -134,7 +132,6 @@
     border-width: $padding-xs;
 
     .banner {
-      padding-top: 200px;
       margin-left: -10px;
       margin-right: -10px;
     }


### PR DESCRIPTION
Keep aspect ratios consistent regardless of screen size.
 - Group banners: 32:9
 - Post banners: 21:9