### PR TITLE
Generate routes for meta tags

### DIFF
--- a/app/routes/bulletin/sunday.js
+++ b/app/routes/bulletin/sunday.js
@@ -17,6 +17,6 @@ export default Ember.Route.extend({
   },
   headTags() {
     const bulletin = this.modelFor(this.routeName);
-    return headTags(bulletin.get("group"), bulletin);
+    return headTags(bulletin.get("group"), bulletin, this.router);
   }
 });

--- a/app/routes/group/bulletin/index.js
+++ b/app/routes/group/bulletin/index.js
@@ -5,6 +5,6 @@ export default Ember.Route.extend({
   headTags() {
     const bulletin = this.modelFor(this.routeName);
     const group = this.modelFor("group");
-    return headTags(group, bulletin);
+    return headTags(group, bulletin, this.router);
   }
 });

--- a/app/routes/group/index.js
+++ b/app/routes/group/index.js
@@ -6,7 +6,7 @@ const KIND_POST = 0;
 
 export default Ember.Route.extend(Pagination, {
   headTags: function() {
-    return headTags(this.modelFor(this.routeName).group);
+    return headTags(this.modelFor(this.routeName).group, this.router);
   },
   model(params) {
     const group = this.modelFor("group");

--- a/app/routes/group/post/index.js
+++ b/app/routes/group/post/index.js
@@ -5,7 +5,7 @@ export default Ember.Route.extend({
   headTags() {
     const post = this.modelFor("group.post");
     const group = this.modelFor("group");
-    return headTags(group, post);
+    return headTags(group, post, this.router);
   },
   titleToken(model) {
     return model.get("title");

--- a/app/utils/head-tags/group/bulletin/index.js
+++ b/app/utils/head-tags/group/bulletin/index.js
@@ -1,15 +1,14 @@
 import ENV from "mcac/config/environment";
 import Ember from "ember";
 
-export default function(group, bulletin) {
-  const canonicalUrl =
-    `${ENV["DOMAIN"]}/${group.get("slug")}/bulletin/${bulletin.get("id")}`;
-
+export default function(group, bulletin, router) {
+  const path = router.generate("group.bulletin.index", group.get("slug"), bulletin);
+  const canonicalUrl = `${ENV["DOMAIN"]}${path}`;
   const bannerUrl = Ember.isEmpty(bulletin.get("bannerUrl")) ?
     "https://mcac.s3.amazonaws.com/bulletins/3e22317c-3b06-40d1-82c9-3c8a0ef2c41c." :
     `https://res.cloudinary.com/${ENV["CLOUDINARY_CLOUD_NAME"]}/image/fetch/w_1200/${bulletin.get("bannerUrl")}`;
 
-  const tags = [{
+  return [{
     type: 'meta',
     tagId: 'meta-og-title',
     attrs: {
@@ -45,6 +44,4 @@ export default function(group, bulletin) {
       content: bannerUrl
     }
   }];
-
-  return tags;
 }

--- a/app/utils/head-tags/group/index.js
+++ b/app/utils/head-tags/group/index.js
@@ -1,7 +1,8 @@
 import ENV from "mcac/config/environment";
 
-export default function(group) {
-  const canonicalUrl = `${ENV["DOMAIN"]}/${group.get("slug")}`;
+export default function(group, router) {
+  const path = router.generate("group.index", group.get("slug"));
+  const canonicalUrl = `${ENV["DOMAIN"]}${path}`;
 
   return [{
     type: 'meta',

--- a/app/utils/head-tags/group/post/index.js
+++ b/app/utils/head-tags/group/post/index.js
@@ -1,7 +1,10 @@
 import ENV from "mcac/config/environment";
 import Ember from "ember";
 
-export default function(group, post) {
+export default function(group, post, router) {
+  const path = router.generate("group.post.index", post);
+  const canonicalUrl = `${ENV["DOMAIN"]}${path}`;
+
   const bannerUrl = Ember.isEmpty(post.get("bannerUrl")) ?
     "https://mcac.s3.amazonaws.com/bulletins/3e22317c-3b06-40d1-82c9-3c8a0ef2c41c." :
     `https://res.cloudinary.com/${ENV["CLOUDINARY_CLOUD_NAME"]}/image/fetch/w_1200/${post.get("bannerUrl")}`;
@@ -22,6 +25,20 @@ export default function(group, post) {
       attrs: {
         property: 'og:image',
         content: bannerUrl
+      }
+    }, {
+      type: 'meta',
+      tagId: 'meta-og-url',
+      attrs: {
+        property: 'og:url',
+        content: canonicalUrl
+      }
+    }, {
+      type: 'link',
+      tagId: 'link-canonical',
+      attrs: {
+        rel: 'canonical',
+        href: canonicalUrl
       }
     }
   ];

--- a/app/utils/head-tags/index.js
+++ b/app/utils/head-tags/index.js
@@ -1,3 +1,4 @@
+import ENV from "mcac/config/environment";
 export default [
   {
     type: 'meta',
@@ -25,14 +26,14 @@ export default [
     tagId: 'meta-og-url',
     attrs: {
       property: 'og:url',
-      content: "https://mcac.church"
+      content: ENV["DOMAIN"]
     }
   }, {
     type: 'link',
     tagId: 'canonical-link',
     attrs: {
       rel: 'canonical',
-      content: 'https://mcac.church'
+      content: ENV["DOMAIN"]
     }
   }
 ];

--- a/tests/acceptance/bulletin/sunday-test.js
+++ b/tests/acceptance/bulletin/sunday-test.js
@@ -9,10 +9,12 @@ moduleForAcceptance('Acceptance | bulletin/sunday');
 test('visiting /sunday', function(assert) {
   const hardcodedSundayBulletinId = 3;
   const sermon = server.create("sermon");
+  const group = server.create("group");
   const bulletin = server.create("bulletin", {
     id: hardcodedSundayBulletinId,
     publishedAt: new Date(2000, 11, 10, 9, 30),
-    sermon: sermon
+    sermon,
+    group
   });
   const announcements = server.createList("announcement", 3, { bulletin });
 

--- a/tests/unit/utils/head-tags/group/bulletin/index-test.js
+++ b/tests/unit/utils/head-tags/group/bulletin/index-test.js
@@ -5,7 +5,20 @@ import ENV from "mcac/config/environment";
 
 module('Unit | Utility | head tags/group/bulletin/index');
 
-test("it populates opengraph tags", function(assert) { const bulletin = Ember.Object.create({
+function stubRouter(assert) {
+  return {
+    generate(route, groupSlug, bulletin) {
+      assert.equal(route, "group.bulletin.index");
+      assert.equal(groupSlug, "random-group");
+      assert.equal(bulletin.get("id"), 123);
+
+      return `/${groupSlug}/bulletin/${bulletin.get("id")}`;
+    }
+  }
+}
+
+test("it populates opengraph tags", function(assert) {
+  const bulletin = Ember.Object.create({
     id: 123,
     name: "My Bulletin",
     bannerUrl: "https://example.com/banner.jpg"
@@ -15,7 +28,7 @@ test("it populates opengraph tags", function(assert) { const bulletin = Ember.Ob
     slug: "random-group"
   });
 
-  const actualTags = headTags(group, bulletin);
+  const actualTags = headTags(group, bulletin, stubRouter(assert));
 
   const expectedTags = [{
     type: 'meta',
@@ -67,7 +80,8 @@ test("without a banner", function(assert) {
     slug: "random-group"
   });
 
-  const ogImage = headTags(group, bulletin).filter(t => t.tagId === "meta-og-image")[0];
+  const ogImage = headTags(group, bulletin, stubRouter(assert))
+    .filter(t => t.tagId === "meta-og-image")[0];
 
   assert.equal(
     ogImage.attrs.content,

--- a/tests/unit/utils/head-tags/group/index-test.js
+++ b/tests/unit/utils/head-tags/group/index-test.js
@@ -5,6 +5,17 @@ import ENV from "mcac/config/environment";
 
 module('Unit | Utility | head tags/group/index');
 
+function stubRouter(assert) {
+  return {
+    generate(route, groupSlug) {
+      assert.equal(route, "group.index");
+      assert.equal(groupSlug, "test-group");
+
+      return `/${groupSlug}`;
+    }
+  }
+}
+
 test("it populates opengraph tags", function(assert) {
   const group = Ember.Object.create({
     name: "My Group",
@@ -13,7 +24,7 @@ test("it populates opengraph tags", function(assert) {
     slug: "test-group"
   });
 
-  const actualTags = headTags(group);
+  const actualTags = headTags(group, stubRouter(assert));
 
   const expectedTags = [{
     type: 'meta',

--- a/tests/unit/utils/head-tags/group/post/index-test.js
+++ b/tests/unit/utils/head-tags/group/post/index-test.js
@@ -17,7 +17,7 @@ test("it populates opengraph tags", function(assert) {
     name: "Random Group"
   });
 
-  const actualTags = headTags(group, post);
+  const actualTags = headTags(group, post, stubRouter(assert));
 
   const expectedTags = [{
     type: 'meta',
@@ -32,6 +32,20 @@ test("it populates opengraph tags", function(assert) {
     attrs: {
       property: 'og:image',
       content: `https://res.cloudinary.com/${ENV["CLOUDINARY_CLOUD_NAME"]}/image/fetch/w_1200/https://example.com/banner.jpg`
+    }
+  }, {
+    type: 'meta',
+    tagId: 'meta-og-url',
+    attrs: {
+      property: 'og:url',
+      content: `${ENV["DOMAIN"]}/stubbed-post-route`
+    }
+  }, {
+    type: 'link',
+    tagId: 'link-canonical',
+    attrs: {
+      rel: 'canonical',
+      href: `${ENV["DOMAIN"]}/stubbed-post-route`
     }
   }];
 
@@ -49,10 +63,22 @@ test("without a banner", function(assert) {
     name: "Random Group"
   });
 
-  const ogImage = headTags(group, post).filter(t => t.tagId === "meta-og-image")[0];
+  const ogImage = headTags(group, post, stubRouter(assert))
+    .filter(t => t.tagId === "meta-og-image")[0];
 
   assert.equal(
     ogImage.attrs.content,
     "https://mcac.s3.amazonaws.com/bulletins/3e22317c-3b06-40d1-82c9-3c8a0ef2c41c."
   );
 });
+
+function stubRouter(assert) {
+  return {
+    generate(route, post) {
+      assert.equal(route, "group.post.index");
+      assert.equal(post.get("id"), 123);
+
+      return "/stubbed-post-route";
+    }
+  }
+}


### PR DESCRIPTION
Instead of hardcoding the url, fetch the routes from router.